### PR TITLE
fix(tekton): add namespace-scoped RBAC for pipeline SA and NotebookValidationJob

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -384,7 +384,7 @@
         "filename": "charts/hub/values.yaml",
         "hashed_secret": "9c2b676ba1927d6f3844b394b0d598054e129953",
         "is_verified": false,
-        "line_number": 496
+        "line_number": 498
       }
     ],
     "docs/ADR-TO-AUTOMATION-MAPPING.md": [
@@ -833,5 +833,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-02T16:24:35Z"
+  "generated_at": "2026-02-16T18:53:55Z"
 }

--- a/charts/hub/templates/tekton-rbac.yaml
+++ b/charts/hub/templates/tekton-rbac.yaml
@@ -1,0 +1,57 @@
+{{- if and .Values.tekton .Values.tekton.enabled }}
+---
+# Role: Model Training Pipeline Permissions (namespace-scoped)
+# Grants the pipeline service account permissions to create/manage NotebookValidationJobs
+# and related resources. Fixes pipeline failure when rbac.clusterScoped.enabled=false (Issue #36).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pipeline-notebook-validation
+  namespace: {{ .Values.main.namespace }}
+  labels:
+    app.kubernetes.io/name: pipeline-notebook-validation
+    app.kubernetes.io/part-of: model-training
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+rules:
+  # NotebookValidationJob management
+  - apiGroups: ["mlops.mlops.dev"]
+    resources: ["notebookvalidationjobs"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["mlops.mlops.dev"]
+    resources: ["notebookvalidationjobs/status"]
+    verbs: ["get", "list", "watch"]
+
+  # InferenceService management (restart-inference-service task)
+  - apiGroups: ["serving.kserve.io"]
+    resources: ["inferenceservices"]
+    verbs: ["get", "list", "watch"]
+
+  # Pod management (restart-inference-service, test-inference-endpoint tasks)
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get", "list"]
+---
+# RoleBinding: Bind pipeline permissions to service account
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pipeline-notebook-validation
+  namespace: {{ .Values.main.namespace }}
+  labels:
+    app.kubernetes.io/name: pipeline-notebook-validation
+    app.kubernetes.io/part-of: model-training
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pipeline-notebook-validation
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.tekton.modelTraining.serviceAccount | default "pipeline" }}
+    namespace: {{ .Values.main.namespace }}
+{{- end }}


### PR DESCRIPTION
Fixes #36

Adds `charts/hub/templates/tekton-rbac.yaml` with a namespace-scoped Role and RoleBinding so the `pipeline` service account can create and manage `NotebookValidationJob` resources when `rbac.clusterScoped.enabled` is false.

- Role `pipeline-notebook-validation` grants get/list/watch/create/update/patch/delete on `notebookvalidationjobs` and status, plus InferenceService/pod access for the pipeline tasks.
- Sync-wave "2" so RBAC exists before Tekton pipeline (wave 3).