### PR TITLE
fix(tekton): GPU pipeline RBAC, CPU/GPU split, and GPU PVC fix (#36, #38, #40)

### DIFF
--- a/charts/hub/templates/tekton-model-training-pipeline.yaml
+++ b/charts/hub/templates/tekton-model-training-pipeline.yaml
@@ -300,7 +300,7 @@ spec:
             volumes:
               - name: model-storage
                 persistentVolumeClaim:
-                  claimName: model-storage-pvc
+                  claimName: model-storage-gpu-pvc
             resources:
               requests:
                 memory: "4Gi"

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -49,7 +49,7 @@ This directory contains Architecture Decision Records for the Self-Healing Platf
 | [ADR-041](041-model-storage-and-versioning-strategy.md) | Model Storage and Versioning Strategy | Accepted | 2025-12-09 | One directory per InferenceService |
 | [ADR-042](042-argocd-deployment-lessons-learned.md) | ArgoCD Deployment Lessons Learned | Accepted | 2025-11-28 | Deployment patterns and best practices |
 || [ADR-043](043-deployment-stability-health-checks.md) | Deployment Stability and Cross-Namespace Health Check Patterns | Implemented | 2026-01-24 | Init containers, startup probes, health checks |
-|| [ADR-053](053-tekton-model-training-pipelines.md) | Tekton Pipelines for Model Training | Proposed | 2026-01-27 | Replaces ArgoCD sync wave approach |
+|| [ADR-053](053-tekton-model-training-pipelines.md) | Tekton Pipelines for Model Training | Proposed | 2026-01-27 | Replaces ArgoCD sync wave approach; amended #38 CPU/GPU split, #40 GPU PVC fix |
 || [ADR-054](054-inferenceservice-model-readiness-race-condition.md) | InferenceService Model Readiness Race Condition Fix | Accepted | 2026-02-06 | Post-deploy restart job for predictor pods |
 
 ### Meta-Documents


### PR DESCRIPTION
## Summary

- **Namespace-scoped RBAC** for the Tekton pipeline ServiceAccount and NotebookValidationJob CRD, fixing permission errors when creating training jobs (#36)
- **CPU/GPU pipeline split** replacing fragile `sed`-based YAML patching with two static pipeline definitions (`model-training-pipeline` for CPU, `model-training-pipeline-gpu` for GPU), enabling custom model support (#38)
- **GPU PVC fix** changing the `run-notebook-validation-gpu` task from `model-storage-pvc` (CephFS) to `model-storage-gpu-pvc` (GP3), since GPU nodes on demo.redhat.com clusters lack the CephFS CSI driver (#40)

## Changes

| File | What changed |
|------|-------------|
| `charts/hub/templates/tekton-rbac.yaml` | New namespace-scoped Role/RoleBinding for pipeline SA |
| `charts/hub/templates/tekton-model-training-pipeline.yaml` | Split into CPU + GPU tasks/pipelines; fixed GPU PVC reference |
| `charts/hub/templates/tekton-model-training-cronjobs.yaml` | predictive-analytics CronJob now uses `model-training-pipeline-gpu` |
| `scripts/trigger-model-training.sh` | Added `--gpu` flag, custom notebook/inference-service params |
| `docs/adrs/053-tekton-model-training-pipelines.md` | Two amendments: CPU/GPU split (Issue #38), GPU PVC fix (Issue #40) |
| `docs/adrs/README.md` | Updated ADR-053 notes column |

## Environment note

The GPU PVC issue was identified on a **demo.redhat.com** provisioned cluster. In other environments where GPU nodes have CephFS drivers available, the storage configuration may differ. See the ADR-053 amendment for details.

## Test plan

- [ ] Trigger CPU pipeline for anomaly-detector and verify training completes
- [ ] Trigger GPU pipeline for predictive-analytics and verify pod mounts `model-storage-gpu-pvc` successfully
- [ ] Verify `copy-gpu-model-to-shared` copies model from GPU PVC to shared PVC
- [ ] Verify model health check and inference endpoint tests pass
- [ ] Confirm CronJobs reference the correct pipeline names

Closes #36, closes #38, closes #40

Made with [Cursor](https://cursor.com)